### PR TITLE
Retime to internal subs (plus more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,18 @@ and it's meant to work nicely alongside `autosub`,
 [trueautosub](https://github.com/fullmetalsheep/mpv-iina-scripts)
 or similar scripts.
 
+This branch tests experimental support for 
+[alass](https://github.com/kaegi/alass) (and tools with similar 
+syntax). This hasn't been fully tested yet but appears to work in 
+GNU/Linux. The basic idea is to first get it to work properly 
+with one alternative subsync tool, and then incorporate support
+for most.
+
 ### Usage
 1. Install [ffsubsync](https://github.com/smacke/ffsubsync).
 You can simply use `pip install ffsubsync`,
 assuming you already have `ffmpeg` installed.
+Alternatively, install [alass](https://github.com/kaegi/alass).
 2. Download `autosubsync.lua` or clone the repo.
 3. If your `ffsubsync` path isn't the default,
 create a config file at `~/.config/mpv/script-opts/autosubsync.conf`
@@ -25,6 +33,14 @@ or else it won't work.
 
 * In GNU/Linux you can use `which ffsubsync` to find out where it is.
 
+* If you'd like to use `alass`, add this line to your 
+`autosubsync.conf` file:
+```
+subsync_path=/usr/local/bin/alass
+subsync_tool=alass
+```
+where `subsync_path` now contains your `alass` path.
+ 
 4. Move `autosubsync.lua` to your scripts folder.
 This is typically in `~/.config/mpv/scripts` (GNU/Linux)
 or `%AppData%\mpv\scripts\` (Windows).

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ subs for your specific language are out of sync.
 Take into account that using this script has the
 same limitations as `ffsubsync`, so subtitles that have
 a lot of extra text or are meant for an entirely different 
-version of the video might not sync properly
+version of the video might not sync properly. `alass` is supposed
+to handle some edge cases better, but I haven't fully tested it yet,
+obtaining similar results with both.
 
-Note that **the subtitle file will be overwritten**, so beware.
+Note that the script will create a new subtitle file, in the same folder as the original, with the `_retimed` suffix at the end.
 
 ### Possible improvements
 * ~~Actually check if the srt file exists before feeding it to ffsubsync.
@@ -70,9 +72,9 @@ Fixed, added some messages too.
 * Test if it works properly in ~~Windows~~ or MacOS, or in mpv-based
 players like [mpv.net](https://github.com/stax76/mpv.net) 
 or [celluloid](https://celluloid-player.github.io/).
-* Modify it to support multiple filenames/languages. 
+* ~~Modify it to support multiple filenames/languages. 
 Since `autosub` and `trueautosub` only use one language at a time and 
-the same subtitle name as the video file, this hasn't been too much of a bother yet.
+the same subtitle name as the video file, this hasn't been too much of a bother yet.~~
 * Add compatibility with 
 [autoload](https://github.com/mpv-player/mpv/blob/master/TOOLS/lua/autoload.lua) 
 to sync all the files in a playlist.

--- a/README.md
+++ b/README.md
@@ -6,46 +6,71 @@ and it's meant to work nicely alongside `autosub`,
 [trueautosub](https://github.com/fullmetalsheep/mpv-iina-scripts)
 or similar scripts.
 
-This branch tests experimental support for 
-[alass](https://github.com/kaegi/alass) (and tools with similar 
-syntax). This hasn't been fully tested yet but appears to work in 
-GNU/Linux. The basic idea is to first get it to work properly 
-with one alternative subsync tool, and then incorporate support
-for most.
+### Installation
+1. Install [FFmpeg](https://wiki.archlinux.org/index.php/FFmpeg):
+    ```
+    $ pacman -S ffmpeg
+    ```
+    Windows users have to manually install FFmpeg from [here](https://ffmpeg.zeranoe.com/builds/). 
+2. Install your retiming program of choice,
+[ffsubsync](https://github.com/smacke/ffsubsync)
+or [alass](https://github.com/kaegi/alass):
+    ```
+    $ pip install ffsubsync
+    ```
+    ```
+    $ trizen -S alass-git # for Arch Linux users
+    ```
 
-### Usage
-1. Install [ffsubsync](https://github.com/smacke/ffsubsync).
-You can simply use `pip install ffsubsync`,
-assuming you already have `ffmpeg` installed.
-Alternatively, install [alass](https://github.com/kaegi/alass).
-2. Download `autosubsync.lua` or clone the repo.
-3. If your `ffsubsync` path isn't the default,
-create a config file at `~/.config/mpv/script-opts/autosubsync.conf` 
-(GNU/Linux) or `%AppData%\mpv\script-opts\` (Windows)
-and add the correct path. For example:
+3. Download `autosubsync.lua` or clone the repo.
+4. Save `autosubsync.lua` to your scripts folder.
+
+    | GNU/Linux | Windows |
+    |---|---|
+    | `~/.config/mpv/scripts` | `%AppData%\mpv\scripts\` | 
+
+### Configuration
+Create a config file:
+
+| GNU/Linux | Windows |
+|---|---|
+| `~/.config/mpv/script-opts/autosubsync.conf` | `%AppData%\mpv\script-opts\autosubsync.conf` | 
+
+Example config:
 ```
-subsync_path=/usr/local/bin/ffsubsync
+# Absolute path to the ffmpeg executable
+#ffmpeg_path=C:/Program Files/ffmpeg/bin/ffmpeg.exe
+ffmpeg_path=/usr/bin/ffmpeg
+
+# Preferred retiming tool
+#subsync_tool=ffsubsync
+subsync_tool=alass
+
+# If your `ffsubsync` path isn't the default, and add the correct path. 
+# For example:
+#subsync_path=/usr/local/bin/ffsubsync
+#subsync_path=/home/user/.local/bin/ffsubsync
+#subsync_path=C:/Program Files/ffsubsync/ffsubsync.exe
+
+If you'd like to use `alass`, uncomment these lines,
+where `subsync_path` now contains your `alass` path.
+#subsync_path=C:/Program Files/ffmpeg/bin/alass.exe
+#subsync_path=/usr/local/bin/alass
+subsync_path=/usr/bin/alass
 ```
+
+### Notes
 * In Windows you need to use forward slashes 
 or double backslashes for your path,
 like `"C:\\Users\\YourPath\\Scripts\\ffsubsync"`
 or `"C:/Users/YourPath/Scripts/ffsubsync"`,
-or else it won't work. 
+or else it won't work.
 
 * In GNU/Linux you can use `which ffsubsync` to find out where it is.
-
-* If you'd like to use `alass`, add these lines to your `autosubsync.conf` file:
-```
-subsync_path=/usr/local/bin/alass
-subsync_tool=alass
-```
-where `subsync_path` now contains your `alass` path.
  
-4. Move `autosubsync.lua` to your scripts folder.
-This is typically in `~/.config/mpv/scripts` (GNU/Linux)
-or `%AppData%\mpv\scripts\` (Windows).
+### Usage
 
-5. When you have an out of sync sub, press `n` to synchronize it.
+When you have an out of sync sub, press `n` to synchronize it.
 
 `ffsubsync` can typically take up to about 20-30 seconds
 to synchronize (I've seen it take as much as 2 minutes

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ You can simply use `pip install ffsubsync`,
 assuming you already have `ffmpeg` installed.
 2. Download `autosubsync.lua` or clone the repo.
 3. If your `ffsubsync` path isn't the default,
-create a config file at `~/.config/mpv/script-opts/autosubsync.conf`
+create a config file at `~/.config/mpv/script-opts/autosubsync.conf` 
+(GNU/Linux) or `%AppData%\mpv\script-opts\` (Windows)
 and add the correct path. For example:
 ```
 subsync_path=/usr/local/bin/ffsubsync
@@ -43,8 +44,13 @@ same limitations as `ffsubsync`, so subtitles that have
 a lot of extra text or are meant for an entirely different 
 version of the video might not sync properly
 
-Note that **the subtitle file will be overwritten**, so beware.
-
+Note that the script will create a new subtitle file, in the same folder 
+as the original, with the `_retimed` suffix at the end.
+### Issues
+If you are having trouble getting it to work, feel free to open an issue, but
+try to check if [ffsubsync](https://github.com/smacke/ffsubsync) works properly
+outside of `mpv` first. If `ffsubsync` isn't working, `autosubsync` will likely
+fail.
 ### Possible improvements
 * ~~Actually check if the srt file exists before feeding it to ffsubsync.
 Pressing n without the proper file will cause ffsubsync to extract the
@@ -54,9 +60,9 @@ Fixed, added some messages too.
 * Test if it works properly in ~~Windows~~ or MacOS, or in mpv-based
 players like [mpv.net](https://github.com/stax76/mpv.net) 
 or [celluloid](https://celluloid-player.github.io/).
-* Modify it to support multiple filenames/languages. 
+* ~~Modify it to support multiple filenames/languages. 
 Since `autosub` and `trueautosub` only use one language at a time and 
-the same subtitle name as the video file, this hasn't been too much of a bother yet.
+the same subtitle name as the video file, this hasn't been too much of a bother yet.~~
 * Add compatibility with 
 [autoload](https://github.com/mpv-player/mpv/blob/master/TOOLS/lua/autoload.lua) 
 to sync all the files in a playlist.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ subsync_tool=alass
 #subsync_path=/home/user/.local/bin/ffsubsync
 #subsync_path=C:/Program Files/ffsubsync/ffsubsync.exe
 
-If you'd like to use `alass`, uncomment these lines,
+If you'd like to use `alass`, uncomment or edit one of these lines,
 where `subsync_path` now contains your `alass` path.
 #subsync_path=C:/Program Files/ffmpeg/bin/alass.exe
 #subsync_path=/usr/local/bin/alass

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ or else it won't work.
 
 * In GNU/Linux you can use `which ffsubsync` to find out where it is.
 
-* If you'd like to use `alass`, add this line to your 
-`autosubsync.conf` file:
+* If you'd like to use `alass`, add these lines to your `autosubsync.conf` file:
 ```
 subsync_path=/usr/local/bin/alass
 subsync_tool=alass

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -259,3 +259,49 @@ function Menu:down()
     self:draw()
 end
 
+------------------------------------------------------------
+-- Menu actions & bindings
+
+menu = Menu:new {
+    items = { 'Sync to audio', 'Sync to an internal subtitle', 'Cancel' },
+    pos_x = 50,
+    pos_y = 50,
+}
+
+menu.keybinds = {
+    { key = 'h', fn = function() menu.close() end },
+    { key = 'j', fn = function() menu:down() end },
+    { key = 'k', fn = function() menu:up() end },
+    { key = 'l', fn = function() menu.act() end },
+    { key = 'down', fn = function() menu:down() end },
+    { key = 'up', fn = function() menu:up() end },
+    { key = 'Enter', fn = function() menu.act() end },
+    { key = 'ESC', fn = function() menu.close() end },
+}
+
+menu.act = function()
+    menu.close()
+
+    if menu.selected == 1 then
+        sync_sub_fn()
+    elseif menu.selected == 2 then
+        sync_to_internal()
+    elseif menu.selected == 3 then
+        menu.close()
+    end
+end
+
+menu.open = function()
+    for _, val in pairs(menu.keybinds) do
+        mp.add_forced_key_binding(val.key, val.key, val.fn)
+    end
+    menu:draw()
+end
+
+menu.close = function()
+    for _, val in pairs(menu.keybinds) do
+        mp.remove_key_binding(val.key)
+    end
+    menu:erase()
+end
+

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -125,7 +125,6 @@ local function sync_sub_fn(timed_sub_path)
     end
 end
 
--- Entry point
 local function sync_to_internal()
     local extracted_sub_filename = os.tmpname()
     os.remove(extracted_sub_filename)
@@ -160,7 +159,6 @@ if config.subsync_path == "" then
         config.subsync_path = get_default_subsync_path()
     end
 end
-mp.add_key_binding("n", "auto_sync_subs", sync_sub_fn)
 
 ------------------------------------------------------------
 -- Menu visuals
@@ -305,3 +303,7 @@ menu.close = function()
     menu:erase()
 end
 
+------------------------------------------------------------
+-- Entry point
+
+mp.add_key_binding("n", "autosubsync-menu", menu.open)

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -180,6 +180,9 @@ function Menu:new(o)
     o.rect_height = o.rect_height or 40
     o.active_color = o.active_color or 'ffffff'
     o.inactive_color = o.inactive_color or 'aaaaaa'
+    o.border_color = o.border_color or '000000'
+    o.text_color = o.text_color or 'ffffff'
+
     return setmetatable(o, self)
 end
 
@@ -192,11 +195,25 @@ function Menu:font_size(size)
     self:append(string.format([[{\fs%s}]], size))
 end
 
-function Menu:apply_color(i)
+function Menu:set_text_color(code)
+    self:append(string.format("{\\1c&H%s%s%s&\\1a&H05&}", code:sub(5, 6), code:sub(3, 4), code:sub(1, 2)))
+end
+
+function Menu:set_border_color(code)
+    self:append(string.format("{\\3c&H%s%s%s&}", code:sub(5, 6), code:sub(3, 4), code:sub(1, 2)))
+end
+
+function Menu:apply_text_color()
+    self:set_border_color(self.border_color)
+    self:set_text_color(self.text_color)
+end
+
+function Menu:apply_rect_color(i)
+    self:set_border_color(self.border_color)
     if i == self.selected then
-        self:set_color(self.active_color)
+        self:set_text_color(self.active_color)
     else
-        self:set_color(self.inactive_color)
+        self:set_text_color(self.inactive_color)
     end
 end
 
@@ -207,22 +224,14 @@ function Menu:draw_text(i)
     self:new_event()
     self:pos(self.pos_x + padding, self.pos_y + self.rect_height * (i - 1) + padding)
     self:font_size(font_size)
-    self:apply_color(i)
+    self:apply_text_color(i)
     self:append(self.items[i])
-end
-
-function Menu:set_color(code)
-    self:append('{\\1c&H')
-    self:append(code:sub(5, 6))
-    self:append(code:sub(3, 4))
-    self:append(code:sub(1, 2))
-    self:append('&\\1a&H10&}')
 end
 
 function Menu:draw_item(i)
     self:new_event()
     self:pos(self.pos_x, self.pos_y)
-    self:apply_color(i)
+    self:apply_rect_color(i)
     self:draw_start()
     self:rect_cw(0, 0 + (i - 1) * self.rect_height, self.rect_width, i * self.rect_height)
     self:draw_stop()

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -84,6 +84,10 @@ local function remove_extension(filename)
     return filename:gsub('%.%w+$', '')
 end
 
+local function get_extension(filename)
+    return filename:match("^.+(%.%w+)$")
+end
+
 local function sync_sub_fn()
     local video_path = mp.get_property("path")
     local subtitle_path = get_active_subtitle_track_path()
@@ -95,7 +99,7 @@ local function sync_sub_fn()
 
     notify("Starting ffsubsync...", nil, 2)
 
-    local retimed_subtitle_path = remove_extension(subtitle_path) .. '_retimed.srt'
+    local retimed_subtitle_path = table.concat { remove_extension(subtitle_path), '_retimed', get_extension(subtitle_path) }
     local ret = subprocess { config.subsync_path, video_path, "-i", subtitle_path, "-o", retimed_subtitle_path }
 
     if ret == nil then

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -126,6 +126,32 @@ local function sync_sub_fn(timed_sub_path)
 end
 
 -- Entry point
+local function sync_to_internal()
+    local extracted_sub_filename = os.tmpname()
+    os.remove(extracted_sub_filename)
+    extracted_sub_filename = extracted_sub_filename .. '.srt'
+
+    local ret = subprocess {
+        config.ffmpeg_path,
+        "-hide_banner",
+        "-nostdin",
+        "-y",
+        "-loglevel", "quiet",
+        "-an",
+        "-vn",
+        "-i", mp.get_property("path"),
+        "-f", "srt",
+        extracted_sub_filename
+    }
+
+    if ret == nil or ret.status ~= 0 then
+        notify("Couldn't extract internal subtitle.\nMake sure the video has internal subtitles.", "error", 7)
+        return
+    end
+
+    sync_sub_fn(extracted_sub_filename)
+end
+
 if config.subsync_path == "" then
     if config.subsync_tool ~= "ffsubsync" then
         -- silently guess alass path if it's not set

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -127,6 +127,11 @@ local function sync_sub_fn(timed_sub_path)
 end
 
 local function sync_to_internal()
+    if not file_exists(config.ffmpeg_path) then
+        notify("Can't find ffmpeg executable.\nPlease specify the correct path in the config.", "error", 5)
+        return
+    end
+
     local extracted_sub_filename = os.tmpname()
     os.remove(extracted_sub_filename)
     extracted_sub_filename = extracted_sub_filename .. '.srt'

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -94,6 +94,13 @@ local function sync_sub_fn(timed_sub_path)
     local reference_file_path = timed_sub_path or mp.get_property("path")
     local subtitle_path = get_active_subtitle_track_path()
 
+    if not file_exists(config.subsync_path) then
+        notify(string.format(
+                "Can't find %s executable.\nPlease specify the correct path in the config.",
+                config.subsync_tool), "error", 5)
+        return
+    end
+
     if file_exists(subtitle_path) == false then
         notify(table.concat { "Subtitle synchronization failed:\nCouldn't find ", subtitle_path or "subtitle file." }, "error", 3)
         return

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -7,7 +7,8 @@ local mpopt = require('mp.options')
 -- Options can be changed here or in a separate config file.
 -- Config path: ~/.config/mpv/script-opts/autosubsync.conf
 local config = {
-    subsync_path = ""  -- Replace the following line if the location of ffsubsync differs from the defaults
+    subsync_path = "",  -- Replace the following line if the location of ffsubsync differs from the defaults
+    subsync_tool = "ffsubsync",    
 }
 mpopt.read_options(config, 'autosubsync')
 
@@ -84,12 +85,19 @@ local function sync_sub_fn()
         return
     end
 
-    notify("Starting ffsubsync...", nil, 2)
-
     local retimed_subtitle_path = remove_extension(subtitle_path) .. '_retimed.srt'
+    
+    local t = {}
+    --really basic check, maybe group programs according to syntax?
+    if config.subsync_tool == "alass" then
+        notify("Starting alass...", nil, 2)
+        t.args = { config.subsync_path, video_path, subtitle_path, retimed_subtitle_path } 
+    else
+        notify("Starting ffsubsync...", nil, 2)    
+        t.args = { config.subsync_path, video_path, "-i", subtitle_path, "-o", retimed_subtitle_path } 
+    end
 
-    local t = { args = { config.subsync_path, video_path, "-i", subtitle_path, "-o", retimed_subtitle_path } }
-    local ret = utils.subprocess(t)
+    local ret = utils.subprocess(t) --deprecated, supports v0.27
 
     if ret == nil then
         notify("Parsing failed or no args passed.", "fatal", 3)

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -55,15 +55,6 @@ local function notify(message, level, duration)
     mp.osd_message(message, duration)
 end
 
-local function subprocess(args)
-    return mp.command_native {
-        name = "subprocess",
-        playback_only = false,
-        capture_stdout = true,
-        args = args
-    }
-end
-
 local function get_active_subtitle_track_path()
     local sub_track_path
     local tracks_count = mp.get_property_number("track-list/count")
@@ -96,7 +87,9 @@ local function sync_sub_fn()
     notify("Starting ffsubsync...", nil, 2)
 
     local retimed_subtitle_path = remove_extension(subtitle_path) .. '_retimed.srt'
-    local ret = subprocess { config.subsync_path, video_path, "-i", subtitle_path, "-o", retimed_subtitle_path }
+
+    local t = { args = { config.subsync_path, video_path, "-i", subtitle_path, "-o", retimed_subtitle_path } }
+    local ret = utils.subprocess(t)
 
     if ret == nil then
         notify("Parsing failed or no args passed.", "fatal", 3)

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -102,7 +102,10 @@ local function sync_sub_fn(timed_sub_path)
     end
 
     if file_exists(subtitle_path) == false then
-        notify(table.concat { "Subtitle synchronization failed:\nCouldn't find ", subtitle_path or "subtitle file." }, "error", 3)
+        notify(table.concat {
+            "Subtitle synchronization failed:\nCouldn't find ",
+            subtitle_path or "external subtitle file."
+        }, "error", 3)
         return
     end
 

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -165,6 +165,7 @@ local function sync_to_internal()
     end
 
     sync_sub_fn(extracted_sub_filename)
+    os.remove(extracted_sub_filename)
 end
 
 if config.subsync_path == "" then

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -127,6 +127,11 @@ end
 
 -- Entry point
 if config.subsync_path == "" then
-    config.subsync_path = get_default_subsync_path()
+    if config.subsync_tool ~= "ffsubsync" then
+        -- silently guess alass path if it's not set
+        config.subsync_path = file_exists('/usr/bin/alass') and '/usr/bin/alass' or '/usr/local/bin/alass'
+    else
+        config.subsync_path = get_default_subsync_path()
+    end
 end
 mp.add_key_binding("n", "auto_sync_subs", sync_sub_fn)

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -7,6 +7,7 @@ local mpopt = require('mp.options')
 -- Options can be changed here or in a separate config file.
 -- Config path: ~/.config/mpv/script-opts/autosubsync.conf
 local config = {
+    ffmpeg_path = "/usr/bin/ffmpeg",
     subsync_path = "",  -- Replace the following line if the location of ffsubsync differs from the defaults
     subsync_tool = "ffsubsync",
 }

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -89,8 +89,8 @@ local function get_extension(filename)
     return filename:match("^.+(%.%w+)$")
 end
 
-local function sync_sub_fn()
-    local video_path = mp.get_property("path")
+local function sync_sub_fn(timed_sub_path)
+    local reference_file_path = timed_sub_path or mp.get_property("path")
     local subtitle_path = get_active_subtitle_track_path()
 
     if file_exists(subtitle_path) == false then
@@ -103,10 +103,10 @@ local function sync_sub_fn()
     local ret
     if config.subsync_tool ~= "ffsubsync" then
         notify("Starting alass...", nil, 2)
-        ret = subprocess { config.subsync_path, video_path, subtitle_path, retimed_subtitle_path }
+        ret = subprocess { config.subsync_path, reference_file_path, subtitle_path, retimed_subtitle_path }
     else
         notify("Starting ffsubsync...", nil, 2)
-        ret = subprocess { config.subsync_path, video_path, "-i", subtitle_path, "-o", retimed_subtitle_path }
+        ret = subprocess { config.subsync_path, reference_file_path, "-i", subtitle_path, "-o", retimed_subtitle_path }
     end
 
     if ret == nil then

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -55,6 +55,15 @@ local function notify(message, level, duration)
     mp.osd_message(message, duration)
 end
 
+local function subprocess(args)
+    return mp.command_native {
+        name = "subprocess",
+        playback_only = false,
+        capture_stdout = true,
+        args = args
+    }
+end
+
 local function get_active_subtitle_track_path()
     local sub_track_path
     local tracks_count = mp.get_property_number("track-list/count")
@@ -87,9 +96,7 @@ local function sync_sub_fn()
     notify("Starting ffsubsync...", nil, 2)
 
     local retimed_subtitle_path = remove_extension(subtitle_path) .. '_retimed.srt'
-
-    local t = { args = { config.subsync_path, video_path, "-i", subtitle_path, "-o", retimed_subtitle_path } }
-    local ret = utils.subprocess(t)
+    local ret = subprocess { config.subsync_path, video_path, "-i", subtitle_path, "-o", retimed_subtitle_path }
 
     if ret == nil then
         notify("Parsing failed or no args passed.", "fatal", 3)

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -274,6 +274,10 @@ menu = Menu:new {
     items = { 'Sync to audio', 'Sync to an internal subtitle', 'Cancel' },
     pos_x = 50,
     pos_y = 50,
+    text_color = 'fff5da',
+    border_color = '2f1728',
+    active_color = 'ff6b71',
+    inactive_color = 'fff5da',
 }
 
 menu.keybinds = {


### PR DESCRIPTION
Hello. I've added a few new options and I think it would be great if you merge them.
* Integrated the alass branch
* If the original subtitle file is not `srt`, the re-timed file retains its extension (most likely .ass).
* If the user forgets to specify path to the `alass`  executable, the scripts tries to guess in default locations.
* An option to retime using internal subtitles as reference. 
* Added a simple ASS-menu instead of multiple key bindings. The menu is invoked by pressing `n` as usual.

Here's how it works: https://youtu.be/obrd4QF6CHU