### PR TITLE
Keep extension of subtitle file

### DIFF
--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -86,7 +86,7 @@ local function sync_sub_fn()
 
     notify("Starting ffsubsync...", nil, 2)
 
-    local retimed_subtitle_path = remove_extension(subtitle_path) .. '_retimed.srt'
+    local retimed_subtitle_path = remove_extension(subtitle_path) .. '_retimed.' .. subtitle_path:match("[^.]+$")
 
     local t = { args = { config.subsync_path, video_path, "-i", subtitle_path, "-o", retimed_subtitle_path } }
     local ret = utils.subprocess(t)


### PR DESCRIPTION
For some reason, converting from ass to srt w/ ffsubsync throws a strange error. In any case, it shouldn't be doing this at all. This pr keeps the extension.