### PR TITLE
Independently set preferred sync engine depending on reference type

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,17 @@ alass_path=C:/Program Files/ffmpeg/bin/alass.exe
 alass_path=/usr/bin/alass
 
 # Preferred retiming tool. Allowed options: 'ffsubsync', 'alass', 'ask'.
-# If set to 'ask', the add-on will ask to choose the tool every time.
-subsync_tool=ask
-subsync_tool=ffsubsync
-subsync_tool=alass
+# If set to 'ask', the add-on will ask to choose the tool every time:
+
+# 1. Preferred tool for syncing to audio.
+audio_subsync_tool=ask
+audio_subsync_tool=ffsubsync
+audio_subsync_tool=alass
+
+# 2. Preferred tool for syncing to another subtitle.
+altsub_subsync_tool=ask
+altsub_subsync_tool=ffsubsync
+altsub_subsync_tool=alass
 
 # Unload old subs (yes,no)
 # After retiming, tell mpv to forget the original subtitle track.

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -23,7 +23,8 @@ local config = {
 
     -- Choose what tool to use. Allowed options: ffsubsync, alass, ask.
     -- If set to ask, the add-on will ask to choose the tool every time.
-    subsync_tool = "ask",
+    audio_subsync_tool = "ask",
+    altsub_subsync_tool = "ask",
 
     -- After retiming, tell mpv to forget the original subtitle track.
     unload_old_sub = true,
@@ -144,7 +145,8 @@ local function mkfp_retimed(sub_path)
 end
 
 local function engine_is_set()
-    if is_empty(config.subsync_tool) or config.subsync_tool == "ask" then
+    local subsync_tool = ref_selector:get_subsync_tool()
+    if is_empty(subsync_tool) or subsync_tool == "ask" then
         return false
     else
         return true
@@ -287,6 +289,14 @@ function ref_selector:get_ref()
     end
 end
 
+function ref_selector:get_subsync_tool()
+    if self.selected == 1 then
+        return config.audio_subsync_tool
+    elseif self.selected == 2 then
+        return config.altsub_subsync_tool
+    end
+end
+
 function ref_selector:act()
     self:close()
 
@@ -338,7 +348,7 @@ function engine_selector:init()
 end
 
 function engine_selector:get_engine_name()
-    return engine_is_set() and config.subsync_tool or self.last_choice
+    return engine_is_set() and ref_selector:get_subsync_tool() or self.last_choice
 end
 
 function engine_selector:act()


### PR DESCRIPTION
Hello! I've replaced the `subsync-tool` setting with individual settings for audio and subtitle tracks, making it possible to independently set the preferred sync engine for each reference type. This is useful if you for example know that you always want to use alass when syncing to subtitles, but would like to manually select an engine when syncing to audio (see #9).

If the user hasn't set the new configuration options in their config file, it will default to `ask` for both. Current behavior can be preserved by duplicating the old setting and renaming both as seen in the updated example. Feel free to rename the new config options if you can think of something more appropriate.

