### PR TITLE
Add option to overwrite original subtitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Supported backends:
     ```
     $ pacman -S ffmpeg
     ```
-    Windows users have to manually install FFmpeg from [here](https://ffmpeg.zeranoe.com/builds/). 
+    Windows users have to manually install FFmpeg from [here](https://ffmpeg.zeranoe.com/builds/).
 2. Install your retiming program of choice,
 [ffsubsync](https://github.com/smacke/ffsubsync), [alass](https://github.com/kaegi/alass) or both:
     ```
@@ -32,8 +32,8 @@ Supported backends:
 
     | GNU/Linux | Windows |
     |---|---|
-    | `~/.config/mpv/scripts` | `%AppData%\mpv\scripts\` | 
-    
+    | `~/.config/mpv/scripts` | `%AppData%\mpv\scripts\` |
+
     To do it in one command:
 
     ```
@@ -48,7 +48,7 @@ Create a config file:
 
 | GNU/Linux | Windows |
 |---|---|
-| `~/.config/mpv/script-opts/autosubsync.conf` | `%AppData%\mpv\script-opts\autosubsync.conf` | 
+| `~/.config/mpv/script-opts/autosubsync.conf` | `%AppData%\mpv\script-opts\autosubsync.conf` |
 
 Example config:
 
@@ -84,6 +84,11 @@ altsub_subsync_tool=alass
 # After retiming, tell mpv to forget the original subtitle track.
 unload_old_sub=yes
 unload_old_sub=no
+
+# Overwrite the original subtitle file.
+# Replace the old subtitle file with the retimed file.
+overwrite_old_sub=yes
+overwrite_old_sub=no
 ```
 
 ## Notes
@@ -94,7 +99,7 @@ or `"C:/Users/YourPath/Scripts/ffsubsync"`,
 or it might not work.
 
 * On GNU/Linux you can use `which ffsubsync` to find out where it is.
- 
+
 ## Usage
 
 When you have an out of sync sub, press `n` to synchronize it.
@@ -109,12 +114,12 @@ subs for your specific language are out of sync.
 
 Take into account that using this script has the
 same limitations as `ffsubsync`, so subtitles that have
-a lot of extra text or are meant for an entirely different 
+a lot of extra text or are meant for an entirely different
 version of the video might not sync properly. `alass` is supposed
 to handle some edge cases better, but I haven't fully tested it yet,
 obtaining similar results with both.
 
-Note that the script will create a new subtitle file, in the same folder 
+Note that the script will create a new subtitle file, in the same folder
 as the original, with the `_retimed` suffix at the end.
 
 ## Issues and feedback

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -30,6 +30,9 @@ local config = {
 
     -- After retiming, tell mpv to forget the original subtitle track.
     unload_old_sub = true,
+
+    -- Overwrite the original subtitle file
+    overwrite_old_sub = false,
 }
 mpopt.read_options(config, 'autosubsync')
 
@@ -129,7 +132,9 @@ local function startswith(str, prefix)
 end
 
 local function mkfp_retimed(sub_path)
-    if not startswith(sub_path, os_temp()) then
+    if config.overwrite_old_sub then
+        return sub_path
+    elseif not startswith(sub_path, os_temp()) then
         return table.concat { remove_extension(sub_path), '_retimed', get_extension(sub_path) }
     else
         return table.concat { remove_extension(mp.get_property("path")), '_retimed', get_extension(sub_path) }


### PR DESCRIPTION
This PR adds an option called `overwrite_old_sub` which when set to true will save the retimed subtitle as the original subtitle.