### PR TITLE
Allow configuring where new subtitle files are written

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ unload_old_sub=no
 # Replace the old subtitle file with the retimed file.
 overwrite_old_sub=yes
 overwrite_old_sub=no
+
+# Directory to write the new subtitle file to.
+# If set to empty, the directory of the original subtitle will be used.
+new_sub_directory=
+new_sub_directory=~~/retimed-subtitles
 ```
 
 ## Notes

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -33,6 +33,10 @@ local config = {
 
     -- Overwrite the original subtitle file
     overwrite_old_sub = false,
+
+    -- Directory to write the new subtitle file to.
+    -- If set to empty, the directory of the original subtitle will be used.
+    new_sub_directory = "",
 }
 mpopt.read_options(config, 'autosubsync')
 
@@ -131,13 +135,38 @@ local function startswith(str, prefix)
     return string.sub(str, 1, string.len(prefix)) == prefix
 end
 
+local function get_retimed_sub_directory(sub_path)
+    local sub_dir, sub_name = utils.split_path(sub_path)
+    local video_dir, video_name = utils.split_path(mp.get_property("path"))
+
+    if config.new_sub_directory ~= "" then
+        return config.new_sub_directory
+    elseif startswith(sub_dir, os_temp()) then
+        return video_dir
+    else
+        return sub_dir
+    end
+end
+
+local function get_retimed_sub_name(sub_path, suffix)
+    local sub_dir, sub_name = utils.split_path(sub_path)
+    local video_dir, video_name = utils.split_path(mp.get_property("path"))
+
+    if startswith(sub_dir, os_temp()) then
+        return table.concat { remove_extension(video_name), suffix, get_extension(sub_name) }
+    else
+        return table.concat { remove_extension(sub_name), suffix, get_extension(sub_name) }
+    end
+end
+
 local function mkfp_retimed(sub_path, suffix)
     if config.overwrite_old_sub then
         return sub_path
-    elseif not startswith(sub_path, os_temp()) then
-        return table.concat { remove_extension(sub_path), suffix, get_extension(sub_path) }
     else
-        return table.concat { remove_extension(mp.get_property("path")), suffix, get_extension(sub_path) }
+        return utils.join_path(
+            get_retimed_sub_directory(sub_path),
+            get_retimed_sub_name(sub_path, suffix)
+        )
     end
 end
 

--- a/autosubsync.lua
+++ b/autosubsync.lua
@@ -131,13 +131,13 @@ local function startswith(str, prefix)
     return string.sub(str, 1, string.len(prefix)) == prefix
 end
 
-local function mkfp_retimed(sub_path)
+local function mkfp_retimed(sub_path, suffix)
     if config.overwrite_old_sub then
         return sub_path
     elseif not startswith(sub_path, os_temp()) then
-        return table.concat { remove_extension(sub_path), '_retimed', get_extension(sub_path) }
+        return table.concat { remove_extension(sub_path), suffix, get_extension(sub_path) }
     else
-        return table.concat { remove_extension(mp.get_property("path")), '_retimed', get_extension(sub_path) }
+        return table.concat { remove_extension(mp.get_property("path")), suffix, get_extension(sub_path) }
     end
 end
 
@@ -206,7 +206,7 @@ local function sync_subtitles(ref_sub_path)
         )
     end
 
-    local retimed_subtitle_path = mkfp_retimed(subtitle_path)
+    local retimed_subtitle_path = mkfp_retimed(subtitle_path, '_retimed')
 
     notify(string.format("Starting %s...", engine_name), nil, 2)
 
@@ -280,10 +280,8 @@ local function sync_to_manual_offset()
     s:shift_timing(sub_delay)
     if track.external == false then
         os.remove(file_path)
-        s.filename = mp.get_property("filename/no-ext") .. "_manual_timing" .. ext
-    else
-        s.filename = remove_extension(s.filename) .. '_manual_timing' .. ext
     end
+    s.filename = mkfp_retimed(file_path, '_manual_timing')
     s:save()
     mp.commandv("sub_add", s.filename)
     if config.unload_old_sub then


### PR DESCRIPTION
I usually store my modified subtitle files in a different directory from the original, so this is a patch to allow configuring autosubsync's output directory.